### PR TITLE
Add FacialAttributes plugin

### DIFF
--- a/docs/Face-services-and-plugins.md
+++ b/docs/Face-services-and-plugins.md
@@ -6,6 +6,8 @@ CompreFace supports these face services and plugins:
 * Face verification service
 * Age detection plugin
 * Gender detection plugin
+* Emotion detection plugin
+* Race detection plugin
 * Landmarks detection plugin
 * Calculator plugin
 * Face mask detection plugin
@@ -132,6 +134,8 @@ This request will recognize faces on the image and return additional information
 The list of possible plugins:
 * age - returns the supposed range of a person’s age in format [min, max]
 * gender - returns the supposed person’s gender
+* emotion - returns the dominant emotion with probability
+* race - returns the dominant race with probability
 * landmarks - returns face landmarks. This plugin is supported by all configurations and returns 5 points of eyes, nose, and mouth
 * calculator - returns face embeddings.  
 * pose - returns head pose in format: `{"pitch": 0.0,"roll": 0.0,"yaw": 0.0}`

--- a/docs/Rest-API-description.md
+++ b/docs/Rest-API-description.md
@@ -475,6 +475,8 @@ Response body on success:
 |----------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | age                        | object  | detected age range. Return only if [age plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                       |
 | gender                     | object  | detected gender. Return only if [gender plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                       |
+| emotion                    | object  | detected emotion. Return only if [emotion plugin](Face-services-and-plugins.md#face-plugins) is enabled
+| race                       | object  | detected race. Return only if [race plugin](Face-services-and-plugins.md#face-plugins) is enabled
 | pose                       | object  | detected head pose. Return only if [pose plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                      |
 | mask                       | object  | detected mask. Return only if [face mask plugin](Face-services-and-plugins.md#face-plugins) is enabled.                                                     |
 | embedding                  | array   | face embeddings. Return only if [calculator plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                   |
@@ -562,6 +564,8 @@ Response body on success:
 |----------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | age                        | object  | detected age range. Return only if [age plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                       |
 | gender                     | object  | detected gender. Return only if [gender plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                       |
+| emotion                    | object  | detected emotion. Return only if [emotion plugin](Face-services-and-plugins.md#face-plugins) is enabled
+| race                       | object  | detected race. Return only if [race plugin](Face-services-and-plugins.md#face-plugins) is enabled
 | pose                       | object  | detected head pose. Return only if [pose plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                      |
 | mask                       | object  | detected mask. Return only if [face mask plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                      |
 | embedding                  | array   | face embeddings. Return only if [calculator plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                   |
@@ -643,6 +647,8 @@ Response body on success:
 |----------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | age                        | object  | detected age range. Return only if [age plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                       |
 | gender                     | object  | detected gender. Return only if [gender plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                       |
+| emotion                    | object  | detected emotion. Return only if [emotion plugin](Face-services-and-plugins.md#face-plugins) is enabled
+| race                       | object  | detected race. Return only if [race plugin](Face-services-and-plugins.md#face-plugins) is enabled
 | pose                       | object  | detected head pose. Return only if [pose plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                      |
 | mask                       | object  | detected mask. Return only if [face mask plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                      |
 | embedding                  | array   | face embeddings. Return only if [calculator plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                   |
@@ -762,6 +768,8 @@ Response body on success:
 | face_matches               | array   | result of face verification                                                                                                                                 |
 | age                        | object  | detected age range. Return only if [age plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                       |
 | gender                     | object  | detected gender. Return only if [gender plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                       |
+| emotion                    | object  | detected emotion. Return only if [emotion plugin](Face-services-and-plugins.md#face-plugins) is enabled
+| race                       | object  | detected race. Return only if [race plugin](Face-services-and-plugins.md#face-plugins) is enabled
 | pose                       | object  | detected head pose. Return only if [pose plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                      |
 | mask                       | object  | detected mask. Return only if [face mask plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                      |
 | embedding                  | array   | face embeddings. Return only if [calculator plugin](Face-services-and-plugins.md#face-plugins) is enabled                                                   |

--- a/embedding-calculator/README.md
+++ b/embedding-calculator/README.md
@@ -97,6 +97,8 @@ Pass to `EXTRA_PLUGINS` comma-separated names of plugins.
 |------------------------------------|----------------|-------------|------------|-------------|
 | agegender.AgeDetector              | age            | agegender   | Tensorflow |             |
 | agegender.GenderDetector           | gender         | agegender   | Tensorflow |             |
+| facialattributes.EmotionDetector   | emotion        | facialattributes | Tensorflow |             |
+| facialattributes.RaceDetector      | race           | facialattributes | Tensorflow |             |
 | insightface.AgeDetector            | age            | insightface | MXNet      | +           |
 | insightface.GenderDetector         | gender         | insightface | MXNet      | +           |
 | facenet.LandmarksDetector          | landmarks      | Facenet     | Tensorflow | +           |

--- a/embedding-calculator/src/services/dto/plugin_result.py
+++ b/embedding-calculator/src/services/dto/plugin_result.py
@@ -27,6 +27,22 @@ class AgeDTO(JSONEncodable):
             'probability': float(age_probability)}
 
 
+class EmotionDTO(JSONEncodable):
+    def __init__(self, emotion, emotion_probability=1.):
+        self.emotion = {
+            'value': emotion,
+            'probability': float(emotion_probability)
+        }
+
+
+class RaceDTO(JSONEncodable):
+    def __init__(self, race, race_probability=1.):
+        self.race = {
+            'value': race,
+            'probability': float(race_probability)
+        }
+
+
 class MaskDTO(JSONEncodable):
     def __init__(self, mask, mask_probability=1.):
         self.mask = {

--- a/embedding-calculator/src/services/facescan/plugins/facialattributes/__init__.py
+++ b/embedding-calculator/src/services/facescan/plugins/facialattributes/__init__.py
@@ -1,0 +1,1 @@
+requirements = ('deepface>=0.0.93',)

--- a/embedding-calculator/src/services/facescan/plugins/facialattributes/facialattributes.py
+++ b/embedding-calculator/src/services/facescan/plugins/facialattributes/facialattributes.py
@@ -1,0 +1,36 @@
+from deepface import DeepFace
+from src.services.facescan.plugins import base
+from src.services.dto import plugin_result
+
+
+class BaseFacialAttributes(base.BasePlugin):
+    """Common functionality for emotion and race detectors."""
+    CACHE_FIELD = '_facial_attributes_cache'
+    ACTIONS = ['emotion', 'race']
+
+    def _analyze(self, face: plugin_result.FaceDTO):
+        result = getattr(face, self.CACHE_FIELD, None)
+        if result is None:
+            result = DeepFace.analyze(img_path=face._face_img, actions=self.ACTIONS, enforce_detection=False)
+            setattr(face, self.CACHE_FIELD, result)
+        return result
+
+
+class EmotionDetector(BaseFacialAttributes):
+    slug = 'emotion'
+
+    def __call__(self, face: plugin_result.FaceDTO) -> plugin_result.EmotionDTO:
+        analysis = self._analyze(face)
+        emotion = analysis.get('dominant_emotion')
+        probability = analysis.get('emotion', {}).get(emotion, 0) / 100.0 if emotion else 0.0
+        return plugin_result.EmotionDTO(emotion=emotion, emotion_probability=probability)
+
+
+class RaceDetector(BaseFacialAttributes):
+    slug = 'race'
+
+    def __call__(self, face: plugin_result.FaceDTO) -> plugin_result.RaceDTO:
+        analysis = self._analyze(face)
+        race = analysis.get('dominant_race')
+        probability = analysis.get('race', {}).get(race, 0) / 100.0 if race else 0.0
+        return plugin_result.RaceDTO(race=race, race_probability=probability)


### PR DESCRIPTION
## Summary
- implement FacialAttributes plugin using DeepFace
- return emotion and race information via new DTOs
- document the new plugin in user documentation
- update DeepFace requirement to 0.0.93

## Testing
- `pytest -m "not integration and not performance"` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_b_685f1aae3308832c83ce6878c2b7838e